### PR TITLE
#1 Automatically disable delaytrain when executing macros

### DIFF
--- a/lua/delaytrain/init.lua
+++ b/lua/delaytrain/init.lua
@@ -17,6 +17,12 @@ local is_enabled = false
 function M.try_delay_keypress(key)
     current_interval = current_grace_period_intervals[key]
 
+    -- Ingore on macro execution
+    if vim.fn.reg_executing() ~= "" then
+        M.send_keypress(key)
+        return
+    end
+
     -- Start a timer on the first keypress to reset the interval
     if current_interval == 0 then
         vim.loop.new_timer():start(vim.g.delaytrain_delay_ms, 0, function()
@@ -27,13 +33,16 @@ function M.try_delay_keypress(key)
     -- Pass the key through only if we haven't reached the grace period
     if current_interval < vim.g.delaytrain_grace_period then
         current_grace_period_intervals[key] = current_interval + 1
+        M.send_keypress(key)
+    end
+end
 
-        vim.api.nvim_feedkeys(
+function M.send_keypress(key)
+    vim.api.nvim_feedkeys(
         vim.api.nvim_replace_termcodes(key, true, false, true),
         'n', 
         false
-        )
-    end
+    )
 end
 
 function M.setup(opts)


### PR DESCRIPTION
There's no reason to have DelayTrain prevent repeated keypresses on macro execution. This fix checks `vim.fn.reg_executing()` for a non-empty string and always sends the keypress when a macro is being executing.