### PR TITLE
option to passthrough key event to ignored buffer filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,14 @@ default DelayTrain mappings are included below:
             ['nv'] = {'h', 'j', 'k', 'l'},
             ['nvi'] = {'<Left>', '<Down>', '<Up>', '<Right>'},
         },
+        ignore_filestypes = {}, -- Example: set to {"help", "NvimTr*"} to
+                                -- disable the plugin for help and NvimTree
     }
 ```
+
+You can define a list of filetypes that will be ignored by delaytrain using
+`ignore_filestypes`. The option accepts a list of strings or patterns. 
+Tip: you can find the filetype for the current buffer using the command `:set ft?`
 
 ### Mappings
 

--- a/doc/delaytrain.txt
+++ b/doc/delaytrain.txt
@@ -45,8 +45,8 @@ following configuration (default settings included):
             ['nv'] = {'h', 'j', 'k', 'l'},
             ['nvi'] = {'<Left>', '<Down>', '<Up>', '<Right>'},
         },
-        ignore_filestypes = {}, -- Example: set to {"help", "NvimTree"} to
-                               -- disable the plugin for help and NvimTree
+        ignore_filestypes = {}, -- Example: set to {"help", "NvimTr*"} to
+                                -- disable the plugin for help and NvimTree
     }
 <
 Keep in mind that the `delay_ms` timer starts on the FIRST keypress and not the 
@@ -62,6 +62,10 @@ inside `delay_ms` before it stops working.
 the default settings, if you hit j and then hit k after 500ms, both keypresses
 will work. If you wait another 200ms and hit j again, the keypress will not
 work.
+
+You can define a list of filetypes that will be ignored by delaytrain using
+`ignore_filestypes`. The option accepts a list of strings or patterns. Tip:
+you can find the filetype for the current buffer using the command `:set ft?`
 
 ------------------------------------------------------------------------------
 MAPPINGS                                                   *delaytrain-mappings*

--- a/doc/delaytrain.txt
+++ b/doc/delaytrain.txt
@@ -45,6 +45,8 @@ following configuration (default settings included):
             ['nv'] = {'h', 'j', 'k', 'l'},
             ['nvi'] = {'<Left>', '<Down>', '<Up>', '<Right>'},
         },
+        ignore_filestypes = {}, -- Example: set to {"help", "NvimTree"} to
+                               -- disable the plugin for help and NvimTree
     }
 <
 Keep in mind that the `delay_ms` timer starts on the FIRST keypress and not the 

--- a/lua/delaytrain/init.lua
+++ b/lua/delaytrain/init.lua
@@ -36,11 +36,13 @@ end
 function M.try_delay_keypress(key)
     current_interval = current_grace_period_intervals[key]
 
-    if has_val(ignore_filetypes, vim.o.filetype) then
-        sendkeys(key)
-        return
+    for _,ign_ft in ipairs(ignore_filetypes) do
+        if vim.o.filetype:match(ign_ft) then
+            sendkeys(key)
+            return
+        end
     end
-
+    --
     -- Start a timer on the first keypress to reset the interval
     if current_interval == 0 then
         vim.loop.new_timer():start(vim.g.delaytrain_delay_ms, 0, function()
@@ -65,7 +67,7 @@ function M.setup(opts)
             vim.g.delaytrain_grace_period = opts.grace_period
         end
 
-        ignore_filetypes = vim.tbl_extend("force", ignore_filetypes, opts.ignore_filetypes)
+        ignore_filetypes = opts.ignore_filetypes or {}
 
         if opts.keys then
             keymaps = opts.keys


### PR DESCRIPTION
Hey thanks for the plugin, I was using vim-hardtime before but it didn't work well with lua/packer but this one does the job perfectly. 

I like to let some buffer types to pass through the key events like `help` buffer where there is no number line to jump with motions. 