### PR TITLE
Allow for remaps

### DIFF
--- a/lua/delaytrain/init.lua
+++ b/lua/delaytrain/init.lua
@@ -85,11 +85,11 @@ function M.enable()
         for _, key in ipairs(keys) do
             -- Check that keys haven't been remapped (e.g. hjkl to dtrn)
             local keypress = ""
-            local remapped = vim.fn.maparg(key, mode_array[1])
-            if remapped == "" then
-              keypress = key
-            else
+            local remapped = vim.fn.maparg(key, mode_array[1], false, true).rhs
+            if remapped then
               keypress = remapped
+            else
+              keypress = key
             end
             -- Set the current grace period for the given key
             current_grace_period_intervals[key] = 0

--- a/lua/delaytrain/init.lua
+++ b/lua/delaytrain/init.lua
@@ -85,8 +85,8 @@ function M.enable()
         for _, key in ipairs(keys) do
             -- Check that keys haven't been remapped (e.g. hjkl to dtrn)
             local keypress = ""
-            local remapped = vim.fn.maparg(key, mode_array[1])
-            if remapped == "" then
+            local remapped = vim.fn.maparg(key, mode_array[1], false, true).rhs
+            if remapped == "" or remapped == nil then
               keypress = key
             else
               keypress = remapped

--- a/lua/delaytrain/init.lua
+++ b/lua/delaytrain/init.lua
@@ -80,8 +80,8 @@ function M.enable()
     is_enabled = true
 
     -- Get an array of all the keys we want to delay regardless of remap status
-    local function get_keypress_array (key, mode_array)
-        local keypress_array = {}
+    local function get_key_mappings (key, mode_array)
+        local key_mappings = {}
         for _, mode in ipairs(mode_array) do
             local keypress = key
             local remapped = vim.fn.maparg(key, mode, false, true).rhs
@@ -90,14 +90,14 @@ function M.enable()
             end
 
             -- If keypress values differ across modes, add the new value here
-            if keypress_array[keypress] then
-                table.insert(keypress_array[keypress].modes, mode)
+            if key_mappings[keypress] then
+                table.insert(key_mappings[keypress].modes, mode)
             else
-                keypress_array[keypress] = {modes = {mode}, isremap = remapped ~= nil}
+                key_mappings[keypress] = {modes = {mode}, isremap = remapped ~= nil}
             end
         end
 
-      return keypress_array
+      return key_mappings
     end
 
     -- Preserve old keymap so it can be restored after calling M.disable()
@@ -116,8 +116,8 @@ function M.enable()
         end
 
         for _, key in ipairs(keys) do
-            local keypress_array = get_keypress_array(key, mode_array)
-            for keypress, key_data in pairs(keypress_array) do
+            local key_mappings = get_key_mappings(key, mode_array)
+            for keypress, key_data in pairs(key_mappings) do
                 if key_data.isremap then
                   preserve_custom_mappings(key, keypress, key_data.modes)
                 end

--- a/lua/delaytrain/init.lua
+++ b/lua/delaytrain/init.lua
@@ -86,10 +86,10 @@ function M.enable()
             -- Check that keys haven't been remapped (e.g. hjkl to dtrn)
             local keypress = ""
             local remapped = vim.fn.maparg(key, mode_array[1])
-            if remapped ~= "" then
-              keypress = remapped
-            else
+            if remapped == "" then
               keypress = key
+            else
+              keypress = remapped
             end
             -- Set the current grace period for the given key
             current_grace_period_intervals[key] = 0


### PR DESCRIPTION
Hello, thanks for the plugin! I was looking at #3 and thought I'd try to propose something. This is my first PR as I'm learning how to code so I hope I'm following the proper procedure.

#### Changes
1. Use `vim.fn.mapargs()` to see if the key has been remapped. If so, set the new parameter/arg `keypress` to `remapped`. Else, `keypress = key` and the functions run with this redundant param. 
2. `current_grace_period_intervals` continues to take `key` so we calculate the interval of the actual key, but `keypress` (the potentially remapped key) is what ultimately gets sent by `send_keypress()`

It's a bit clunky and I don't love passing a mostly redundant second argument `keypress` to `try_delay_keypress()`, especially for what's likely a rare use case, but thought I'd bring it up. I tested this with this config:

```lua
local map = vim.api.nvim_set_keymap
map("n", "d", "h", { noremap = true })
map("n", "t", "j", { noremap = true })
map("n", "r", "k", { noremap = true })
map("n", "n", "l", { noremap = true })

require('delaytrain').setup {
  delay_ms = 1000, -- How long repeated usage of a key should be prevented
  grace_period = 1, -- How many repeated keypresses are allowed
  keys = { -- Which keys (in which modes) should be delayed
    -- ['nv'] = { 'h', 'j', 'k', 'l' },
    ['nv'] = { 'd', 't', 'r', 'n' },
    ['nvi'] = { '<Left>', '<Down>', '<Up>', '<Right>' },
  },
}
```

Also, n.b., later remaps of the same key (e.g. by a plugin in `after/plugins`) would override this.
